### PR TITLE
Implement nginx keepalive timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ examples.json
 tee
 .ash_history
 .terraform.d/
+.terraform.lock.hcl
 terraform/provision/.cache
 *kubeconfig*
 .kube*

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -52,6 +52,7 @@ resource "helm_release" "solrcloud" {
       "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-read-timeout"    = "\"6000\""
       "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-send-timeout"    = "\"6000\""
       "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/send-timeout"          = "\"6000\""
+      "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/keepalive_timeout"     = "\"6000\""
     }
     content {
       name  = set.key


### PR DESCRIPTION
This is based on solr cluster nodes losing connection with each other.  Reference: http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout

This was a change I had made a while ago.  Not sure if we actually need it.  Just putting it here to document it.