### PR TITLE
Allow more tolerance for ZK latency

### DIFF
--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -46,6 +46,7 @@ resource "helm_release" "solrcloud" {
       "podOptions.resources.requests.cpu"                                                  = var.solrCpu       # How much vCPU to request from the scheduler
       "replicas"                                                                           = var.replicas      # How many replicas you want
       "solrOptions.javaMemory"                                                             = var.solrJavaMem   # How much memory to give each replica
+      "solrOptions.javaOpts"                                                               = "-DzkClientTimeout=600000"
       "solrOptions.security.authenticationType"                                            = "Basic"
       "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-body-size"       = "999m"
       "ingressOptions.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-connect-timeout" = "\"6000\""


### PR DESCRIPTION
Based on feedback from SolrCloud peers, this update would allow it to be more okay for ZooKeeper and Solr to have more latency between them