### PR TITLE
Update display_name for Solr on ECS + fix outputs

### DIFF
--- a/solr-on-ecs.yml
+++ b/solr-on-ecs.yml
@@ -1,8 +1,8 @@
 version: 1
 name: solr-on-ecs
 id: 182612a5-e2b7-4afc-b2b2-9f9d066875d1
-description: Fault-tolerant and highly-available distributed indexing and searching using Apache Solr
-display_name: SolrCloud
+description: Independent indexing and searching using Apache Solr
+display_name: Solr on ECS
 image_url: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png
 documentation_url: https://lucene.apache.org/solr/resources.html
 support_url: https://github.com/GSA/datagov-brokerpak-solr

--- a/terraform/standalone_ecs/bind/outputs.tf
+++ b/terraform/standalone_ecs/bind/outputs.tf
@@ -1,6 +1,6 @@
 
 output "uri" { value = var.solr_admin_url }
-output "domain" { value = var.solr_admin_url }
+output "domain" { value = replace(var.solr_admin_url, "https://", "") }
 output "username" { value = random_uuid.username.result }
 output "password" { value = nonsensitive(random_password.password.result) }
 


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3826

`cf update-service-broker` was able to get the new service plan through the end-users.  This fixes the integration of the solr service with our ckan app.