### PR TITLE
Keep the admin init service running

### DIFF
--- a/terraform/standalone_ecs/provision/admin.tf
+++ b/terraform/standalone_ecs/provision/admin.tf
@@ -59,7 +59,8 @@ resource "aws_ecs_task_definition" "solr-admin-init" {
         "curl -v -L -w \"%%{http_code}\n\" --user 'catalog:Bleeding-Edge' 'http://solr.null/solr/admin/authentication' --connect-to solr.null:80:$solr_ip:8983 -H 'Content-type:application/json' --data '${local.create_user_json}';",
         "curl -v -L -w \"%%{http_code}\n\" --user 'catalog:Bleeding-Edge' 'http://solr.null/solr/admin/authorization' --connect-to solr.null:80:$solr_ip:8983 -H 'Content-type:application/json' --data '${local.set_role_json}';",
         "curl -v -L -w \"%%{http_code}\n\" --user '${random_uuid.username.result}:${random_password.password.result}' 'http://solr.null/solr/admin/authorization' --connect-to solr.null:80:$solr_ip:8983 -H 'Content-type:application/json' --data '${local.clear_role_json}';",
-        "curl -v -L -w \"%%{http_code}\n\" --user '${random_uuid.username.result}:${random_password.password.result}' 'http://solr.null/solr/admin/authentication' --connect-to solr.null:80:$solr_ip:8983 -H 'Content-type:application/json' --data '${local.delete_user_json}'",
+        "curl -v -L -w \"%%{http_code}\n\" --user '${random_uuid.username.result}:${random_password.password.result}' 'http://solr.null/solr/admin/authentication' --connect-to solr.null:80:$solr_ip:8983 -H 'Content-type:application/json' --data '${local.delete_user_json}';",
+        "sleep infinity"
       ])]
 
       logConfiguration = {


### PR DESCRIPTION
To save costs associated with unintended ECS restarts of the service upon exit.