### PR TITLE
Refactor local domain to be Solr-specific

### DIFF
--- a/terraform/standalone_ecs/provision/vpc.tf
+++ b/terraform/standalone_ecs/provision/vpc.tf
@@ -27,7 +27,7 @@ module "vpc" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "solr" {
-  name        = "solr${local.lb_name}"
+  name        = "local${split("-", local.lb_name)[0]}"
   description = "Internal solr-to-solr communication link"
   vpc         = module.vpc.vpc_id
 }

--- a/terraform/standalone_ecs/provision/vpc.tf
+++ b/terraform/standalone_ecs/provision/vpc.tf
@@ -27,7 +27,7 @@ module "vpc" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "solr" {
-  name        = "local${split("-", local.lb_name)[0]}"
+  name        = "solr-${local.lb_name}"
   description = "Internal solr-to-solr communication link"
   vpc         = module.vpc.vpc_id
 }


### PR DESCRIPTION
Private domain needs to use the valid naming convention of Top-Level Domains.

It turns out TLDs can support hyphens,
- https://tools.ietf.org/id/draft-liman-tld-names-00.html#rfc.section.2