### PR TITLE
lb name need to be 32 or less

### DIFF
--- a/terraform/ecs/provision/admin.tf
+++ b/terraform/ecs/provision/admin.tf
@@ -6,7 +6,7 @@ resource "random_password" "password" {
 }
 
 locals {
-  solr_url = "${local.lb_name}.${aws_service_discovery_private_dns_namespace.solr.name}"
+  solr_url = "${local.lb_name}-leader.${aws_service_discovery_private_dns_namespace.solr.name}"
   solr_follower_urls = [for follower in range(0, var.solrFollowerCount) :
     "${local.lb_name}-follower-${follower}.${aws_service_discovery_private_dns_namespace.solr.name}"
   ]

--- a/terraform/ecs/provision/lb-leader.tf
+++ b/terraform/ecs/provision/lb-leader.tf
@@ -1,10 +1,10 @@
 
 locals {
-  lb_name = substr(var.instance_name, 0, 29)
+  lb_name = substr(var.instance_name, 0, 13)
 }
 
 resource "aws_lb" "solr" {
-  name               = "${local.lb_name}-lb"
+  name               = "${local.lb_name}-leader-lb"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.solr-lb-sg.id]

--- a/terraform/ecs/provision/private-dns.tf
+++ b/terraform/ecs/provision/private-dns.tf
@@ -6,7 +6,7 @@ resource "aws_service_discovery_private_dns_namespace" "solr" {
 }
 
 resource "aws_service_discovery_service" "solr" {
-  name = local.lb_name
+  name = "${local.lb_name}-leader"
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.solr.id


### PR DESCRIPTION
fix error when lb name too long
```
Error: "name" cannot be longer than 32 characters:
"7336fe84-ecdf-4cd7-9562-1cb74-follower-lb"  with
aws_lb.solr-follower[0],  on lb-follower.tf line 3, in resource
"aws_lb" "solr-follower"...
```