### PR TITLE
fix: change solr locktype to none

### DIFF
--- a/terraform/ecs/provision/follower.tf
+++ b/terraform/ecs/provision/follower.tf
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "solr-follower-no-efs" {
         "sed -i 's/SOLR_REPLICATION_LEADER_PASSWORD/${random_password.password.result}/g' /tmp/ckan_config/solrconfig.xml;",
         "chown -R 8983:8983 /var/solr/data;",
         "cd -; su -c \"",
-        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrFollowerMemInG}g -Dsolr.disable.shardsWhitelist=true\" -m solr"
+        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrFollowerMemInG}g -Dsolr.lock.type=none -Dsolr.disable.shardsWhitelist=true\" -m solr"
       ])]
 
       portMappings = [
@@ -76,7 +76,7 @@ resource "aws_ecs_task_definition" "solr-follower" {
         "sed -i 's/SOLR_REPLICATION_LEADER_PASSWORD/${random_password.password.result}/g' /tmp/ckan_config/solrconfig.xml;",
         "chown -R 8983:8983 /var/solr/data;",
         "cd -; su -c \"",
-        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrFollowerMemInG}g -Dsolr.disable.shardsWhitelist=true\" -m solr"
+        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrFollowerMemInG}g -Dsolr.lock.type=none -Dsolr.disable.shardsWhitelist=true\" -m solr"
       ])]
 
       portMappings = [

--- a/terraform/ecs/provision/leader.tf
+++ b/terraform/ecs/provision/leader.tf
@@ -120,7 +120,7 @@ resource "aws_ecs_task_definition" "solr-no-efs" {
         "rm -rf /tmp/ckan_config/solrconfig_follower.xml;",
         "chown -R 8983:8983 /var/solr/data;",
         "cd -; su -c \"",
-        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrMemInG}g\" -m solr"
+        "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -m ${local.solrMemInG}g -Dsolr.lock.type=none\" -m solr"
       ])]
 
       portMappings = [


### PR DESCRIPTION
during task restart, the stopped task might take a while to release
the Solr core on EFS before new task can use it.

We often see this error on the newly started SOLR when we stop a SOLR task. When this error happens, the new SOLR is not usable until we stop it again. Changing locktype to `none` should prevent this error from happening. It is simple and safe in our setup.
https://cwiki.apache.org/confluence/display/lucene/AvailableLockFactories#
```
SolrCore Initialization Failures
ckan: org.apache.solr.common.SolrException:org.apache.solr.common.SolrException: Index dir '/var/solr/data/ckan/data/index/' of core 'ckan' is already locked. The most likely cause is another Solr server (or another solr core in this server) also configured to use this directory; other possible causes may be specific to lockType: native
Please check your logs for more information
```
