### PR TITLE
ECS Cleanup Script - Fix input/outputs

### DIFF
--- a/bin/clean_ecs.go
+++ b/bin/clean_ecs.go
@@ -38,14 +38,12 @@ func queryResources() {
 	}
   for region, all_resources := range accountResources.Resources {
     // fmt.Printf("Region: [%s]\n", region)
-    for class_name, list_resources := range all_resources.Resources {
+    for _, list_resources := range all_resources.Resources {
       // fmt.Printf("AWS Resource Class: [%s]\n", resourceTypes[class_name])
       for _, resource := range list_resources.ResourceIdentifiers() {
         fmt.Println("\n\n\n\n\n")
-        for group, command := range tag_commands {
-          checkTags(resource, class_name, group, command)
-        }
-        if interact(fmt.Sprintf("%s : %s : %s", region, resultTypes[class_name], resource)) {
+        checkTags(resource, getServiceType(resource), tag_commands[getServiceType(resource)])
+        if interact(fmt.Sprintf("%s : %s : %s", region, getServiceType(resource), resource)) {
           wg.Add(1)
           go deleteResource(&wg, list_resources, resource)
         }


### PR DESCRIPTION
The old method of figuring out what service the script was dealing with at any given time was not reliable.  This uses regular expressions to grab the right service type based on the id.

Previously, when a list of AWS resources were given to `cloud-nuke`, `cloud-nuke` would return a different order of the list that was non-deterministic.  To compensate for that, we are identifying the service type based on the format of the ID.