### PR TITLE
Solr Restart: add packages to Dockerfile

### DIFF
--- a/terraform/ecs/provision/Dockerfile
+++ b/terraform/ecs/provision/Dockerfile
@@ -1,10 +1,6 @@
-FROM hashicorp/terraform:0.13.7 as terraform
-
-FROM alpine/k8s:1.20.7
-
-COPY --from=terraform /bin/terraform /bin/terraform 
+FROM hashicorp/terraform:1.1.5
 
 RUN apk update
-RUN apk add --update git 
+RUN apk add --update git zip curl python3 py3-pip
 
 ENTRYPOINT ["/bin/sh"]

--- a/terraform/ecs/provision/restarts.tf
+++ b/terraform/ecs/provision/restarts.tf
@@ -96,7 +96,7 @@ resource "local_file" "app_no_slack" {
 
 resource "null_resource" "package_slack_sdk" {
   provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
+    interpreter = ["/bin/sh", "-c"]
     command = <<-EOF
       pip install --target ./package slack-sdk
       cd package && zip -r ../restart_app.zip ./* && cd -


### PR DESCRIPTION
- use newer terraform:1.1.5, same as the version specified in manifest.yml
- add packages to handle restart script
