### PR TITLE
Point to intermediary registry to proxy requests

### DIFF
--- a/terraform/ecs/provision/versions.tf
+++ b/terraform/ecs/provision/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source  = "terraform-registry.apps.internal/hashicorp/aws"
       version = "~> 3.63"
     }
     template = {
-      source = "hashicorp/template"
+      source = "terraform-registry.apps.internal/hashicorp/template"
     }
   }
   required_version = "~> 1.1"

--- a/terraform/ecs/provision/vpc.tf
+++ b/terraform/ecs/provision/vpc.tf
@@ -3,7 +3,7 @@ data "aws_availability_zones" "available" {
 }
 
 module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-registry.apps.internal/terraform-aws-modules/vpc/aws"
   version = "3.11.4"
   name    = "solr-${var.instance_name}-vpc"
   cidr    = "10.31.0.0/16"


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4118

This is not working (as yet, if ever), but saving just in case we ever need it