### PR TITLE
Discuss cluster resizing and provide credentials to fix issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ docs.
 Huge props go to @josephlewis42 of Google for publishing and publicizing the
 brokerpak concept, and to the Pivotal team running with the concept!
 
+## IMPORTANT: Cluster resizing can be *very* challenging
+
+Solr clusters can be created using different numbers of followers with the
+`solrFollowerCount` parameter, and that parameter can be changed with an
+update operation. Because of how we configure followers with a
+common admin user (see `terraform/ecs/provision/admin.tf`) if we _increase_
+the `solrFollowerCount`, then newly created followers will not have the
+admin user and password set. When this happens, those clusters will fail
+`bind` and `unbind` operations because the new follower(s) will not respond
+as expected.
+
+The simplest thing to do is to never increase the number of followers in a
+Solr cluster. If it isn't possible to use a new Solr cluster with more
+followers, increasing the number of followers can be done, but the new
+followers will need to be manually configured with the admin user and password
+using the API calls from the ECS task in `admin.tf`.
 
 ## Prerequisites
 

--- a/terraform/ecs/bind/main.tf
+++ b/terraform/ecs/bind/main.tf
@@ -88,6 +88,7 @@ resource "null_resource" "manage_solr_user" {
       solr_follower_urls=(${replace(self.triggers.domain_followers, ",", "")})
       for solr_follower_url in $${solr_follower_urls[@]}
       do
+      echo "$${solr_follower_url}: "
         curl \
           -s -f -L \
           -o /dev/null \

--- a/terraform/ecs/bind/outputs.tf
+++ b/terraform/ecs/bind/outputs.tf
@@ -5,8 +5,11 @@ output "domain_replica" { value = replace(var.solr_follower_url, "https://", "")
 output "username" { value = random_uuid.username.result }
 output "password" { value = nonsensitive(random_password.password.result) }
 
-output "solr_admin_user" { value = "(hidden)" }
-output "solr_admin_pass" { value = "(hidden)" }
+# all users are admins, so including this does not change security risk
+# but it does allow using these to fix broken clusters
+output "solr_admin_user" { value = var.solr_admin_user }
+output "solr_admin_pass" { value = var.solr_admin_pass }
+
 output "solr_follower_url" { value = "(hidden)" }
 output "solr_leader_url" { value = "(hidden)" }
 output "solr_follower_individual_urls" { value = var.solr_follower_individual_urls }


### PR DESCRIPTION
GSA/data.gov#5185 wants a fix for enlarging Solr clusters via the brokerpak. The methods that we currently use make that very difficult because new followers don't benefit from the initialization in our `solr-admin-init` ECS task. Instead of trying to invent a new method to initialize followers, this PR provides a warning about this issue and also provides the credentials that are needed to fix any issues that might have happened.

There is no additional security risk from exposing these credentials because all of our users are admins and if Solr user credentials are compromised in our `cf env`, then there is already admin access to the Solr cluster.

As with all brokerpak changes, after the PR is merged, this will need to be tagged to cause a brokerpak release to happen, then the released version incorporated in the `datagov-ssb` repository which can then be tested on the `development` branch and eventually merged to `main` there.